### PR TITLE
Adds Vulnerable fastapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # dependabot_python_test
 
-Package has dependency of `requests >= 2.0.0`.
+Example of dependabot not alerting on vulnerable dependencies specified with only a lower-bound.
 
-Hoping dependabot raises security alerts based on (not exhaustive list) following dependencies:
-- https://github.com/advisories/GHSA-652x-xj99-gmcc
+```toml
+dependencies = [
+    "requests >= 2.0.0"
+]
+```
 
+Was hoping dependabot would bump the lower-bound version to the lowest version without a vulnerability.
+
+Vulnerable dependencies and GitHub advisory entries (not exhaustive - I didn't figure out how to search on package name):
+- requests
+    - https://github.com/advisories/GHSA-9wx4-h78v-vm56
+    - https://github.com/advisories/GHSA-cfj3-7x9c-4p3h
+    - https://github.com/advisories/GHSA-652x-xj99-gmcc
+    - https://github.com/advisories/GHSA-x84v-xcm2-53pg
+- fastapi
+    - https://github.com/advisories/GHSA-8h2j-cgx8-6xv7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dependabot_python_test"
-version = "0.1.0"
+version = "0.1.1"
 description = "dependabot python lower-bound dependency test"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -12,7 +12,8 @@ maintainers = [
     {name="Liam Mahoney", email="lmahoney@oshkoshcorp.com"}
 ]
 dependencies = [
-    "requests >= 2.0.0"
+    "requests >= 2.0.0",
+    "fastapi >= 0.60.0"
 ]
 
 [build-system]


### PR DESCRIPTION
"fastapi >= 0.60.0" would possibly download versions of fastapi < 0.65.2 which is vulnerable https://github.com/advisories/GHSA-8h2j-cgx8-6xv7.

Hoping this would trigger a security alert / PR. In testing it has not.